### PR TITLE
Assistant checkpoint: 新增getVersionAndEnvProject API，组合env和version数据

### DIFF
--- a/src/main/java/com/hu/oneclick/controller/SignOffController.java
+++ b/src/main/java/com/hu/oneclick/controller/SignOffController.java
@@ -58,6 +58,11 @@ public class SignOffController {
         return customFieldsService.getPossBile("issueStatus");
     }
 
+    @GetMapping("/getVersionAndEnvProject")
+    public Resp<Map<String, Object>> getVersionAndEnvProject(@RequestParam String projectId) {
+        return customFieldsService.getVersionAndEnvProject(projectId);
+    }
+
     @GetMapping("/getTestCycleDetail")
     public Resp<List<Map<String, String>>> getTestCycleVersion(@RequestParam String projectId, @RequestParam String env, @RequestParam String version) {
         return testCycleService.getTestCycleVersion(projectId, env, version);

--- a/src/main/java/com/hu/oneclick/server/service/CustomFieldsService.java
+++ b/src/main/java/com/hu/oneclick/server/service/CustomFieldsService.java
@@ -9,6 +9,7 @@ import com.hu.oneclick.model.domain.vo.CustomFileldLinkVo;
 
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 
 /**
  * <p>
@@ -36,7 +37,9 @@ public interface CustomFieldsService {
 
     List<CustomFileldLinkVo> getAllCustomListByScopeId(Long scopeId);
 
-    Resp<List<CustomFieldPossBileDto>> getPossBile(String fieldName);
-    
     Resp<List<CustomFieldPossBileDto>> getPossBile(String fieldName, String projectId);
+
+    Resp<List<CustomFieldPossBileDto>> getPossBile(String fieldName);
+
+    Resp<Map<String, Object>> getVersionAndEnvProject(String projectId);
 }


### PR DESCRIPTION
Assistant generated file changes:
- src/main/java/com/hu/oneclick/controller/SignOffController.java: 添加getVersionAndEnvProject API方法, 添加Map导入
- src/main/java/com/hu/oneclick/server/service/CustomFieldsService.java: 添加getVersionAndEnvProject方法声明
- src/main/java/com/hu/oneclick/server/service/impl/CustomFieldsServiceImpl.java: 实现getVersionAndEnvProject方法 实现getVersionAndEnvProject方法
添加Map和HashMap导入

---

User prompt:

好啦 ，现在我们关注开发 API 新的 API
getVersionAndEnvProject?projectId=1874424342973054977 下面是我们想要返回的结果。

这个 API 的结果 实际上是下面这2 个API 的 SQL 的总合。 但是因为我们是在开发一个新的 API， 我们要保证 这2个 API 功能与 返回的结果不变。 开发上面这个 新的 API

总结上面的教训，我们要谨慎地修改，吸取教训。
你看下代码，先分析如何修改
getProjectVersion?projectId=1874424342973054977
getProjectEnv?projectId=1874424342973054977

{
    "code": "200",
    "msg": "调用成功。",
    "total": "",
    "httpCode": 200,
    "data": {
        "env": {
            "possible_value": [
                "{\"order_2\": \"开发\", \"order_3\": \"测试\", \"order_4\": \"在线\"}"
            ],
            "possible_value_child": [
                "{\"order_1\": \"usr vh[\"}"
            ]
        },
        "version": {
            "possible_value": [
                "{\"order_1\": \"1.0.0.0\", \"order_2\": \"2.0.0.0\", \"order_3\": \"3.0.0.0\", \"order_4\": \"4.0.0.0\", \"order_5\": \"5.0.0.0\", \"order_6\": \"6.0.0.0\"}"
            ],
            "possible_value_child": [
                "{\"order_1\": \"7.0.0.0\", \"order_2\": \"8.0.0.0\", \"order_3\": \"9.0.0\", \"order_4\": \"1.1.0\", \"order_5\": \"1.1.2\", \"order_6\": \"1.1.3.0\"}"
            ]
        }
    }
}

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 11def3f6-66ab-4ef2-88bc-19ab6fcf1446